### PR TITLE
SSHPASS

### DIFF
--- a/RemotePython/RemotePython.py
+++ b/RemotePython/RemotePython.py
@@ -55,7 +55,7 @@ class RemotePython(object):
         try:
             call(self.__ssh_string + ['scp', script, '%s:%s' % (self.__remote_client, script)])
         except:
-            print "Call failed: scp %s %s:%s" % (script, self.__remote_client, script)
+            print "Call failed: %s scp %s %s:%s" % (' '.join(self.__ssh_string),script, self.__remote_client, script)
             raise
     
     def __removeScript(self, script=None):

--- a/RemotePython/RemotePython.py
+++ b/RemotePython/RemotePython.py
@@ -22,7 +22,7 @@ class RemotePython(object):
         self.__remote_client = '%s@%s' % (self.__user, self.__ip)
 
         #Use sshpass if available ... Should only be used for testing purposes.
-        if (os.environ.get('SSHPASS') != 'None'):
+        if (os.environ.get('SSHPASS', 'None') != 'None'):
             self.__ssh_string = ['sshpass', '-e']
         else:
             self.__ssh_string = ''

--- a/RemotePython/RemotePythonUnitTest.py
+++ b/RemotePython/RemotePythonUnitTest.py
@@ -3,6 +3,7 @@ Created on Mar 6, 2016
 
 @author: allexveldman
 '''
+import os
 import unittest
 from RemotePython import RemotePython
 from getpass import getuser
@@ -12,7 +13,7 @@ IP = 'localhost'
 USER = getuser()
 
 # LOCAL_UNAME should be the result you get from running 'uname -s' on your local machine
-LOCAL_UNAME = 'Darwin'
+LOCAL_UNAME = 'Linux'
 
 class Test(unittest.TestCase):
     ''' Class containing unittests for the RemotePython module '''
@@ -39,8 +40,8 @@ class Test(unittest.TestCase):
         if IP == 'localhost':
             print "Run command on a remote machine or create a simlink on your own machine"
         else:
-            ret = obj.runCommand(['testCommand'],load_env=True)
-            self.assertIn('ArdPi', ret)
+            ret = obj.runCommand(['echo', 'test'],load_env=True)
+            self.assertIn('test', ret)
 
     def testRemoveScript(self):
         ''' Test if hidden function '__removeScript' works '''

--- a/RemotePython/RemotePythonUnitTest.py
+++ b/RemotePython/RemotePythonUnitTest.py
@@ -17,8 +17,7 @@ LOCAL_UNAME = 'Linux'
 
 # To avoid all the password requests, install sshpass on your local system
 # and set the environment variable SSHPASS to your password. In Linux, this is done like so:
-# echo "export SSHPASS=pass" >> ~/.profile
-# and then logging in again.
+# $ export SSHPASS=password
 
 class Test(unittest.TestCase):
     ''' Class containing unittests for the RemotePython module '''

--- a/RemotePython/RemotePythonUnitTest.py
+++ b/RemotePython/RemotePythonUnitTest.py
@@ -44,8 +44,8 @@ class Test(unittest.TestCase):
         if IP == 'localhost':
             print "Run command on a remote machine or create a simlink on your own machine"
         else:
-            ret = obj.runCommand(['echo', 'test'],load_env=True)
-            self.assertIn('test', ret)
+            ret = obj.runCommand(['testCommand'],load_env=True)
+            self.assertIn('ArdPi', ret)
 
     def testRemoveScript(self):
         ''' Test if hidden function '__removeScript' works '''

--- a/RemotePython/RemotePythonUnitTest.py
+++ b/RemotePython/RemotePythonUnitTest.py
@@ -37,12 +37,12 @@ class Test(unittest.TestCase):
         
     def testLoadEnv(self):
         ''' Run a command with loading the environment, needs a command named 'testCommand' on the target 
-        I created a simlink in my /home/allex/bin to the ls command in /bin
+        I created a symbolic link in my /home/allex/bin to the ls command in /bin
         Also create a file or object called ArdPi in the user home dir.'''
         #TODO: change this test so it creates a file and cleans up afterward on the target machine
         obj = RemotePython(ip=IP, user=USER)
         if IP == 'localhost':
-            print "Run command on a remote machine or create a simlink on your own machine"
+            print "Run command on a remote machine or create a symbolic link on your own machine"
         else:
             ret = obj.runCommand(['testCommand'],load_env=True)
             self.assertIn('ArdPi', ret)


### PR DESCRIPTION
Generalized the test and RemotePython to make it easier to unit test:

 - If SSHPASS variable is set, constructor will inject extra sshpass -e into the check_output call. (Maybe it should be placed somewhere else than in constructor?)
 - Made testRunCommand more standardized (No need for ArdPi I think)
 - Added ssh_string variable to check_output calls
 - Fixed issue where error print would print out command as a list.