### PR TITLE
Integration

### DIFF
--- a/RemotePython/RemotePythonUnitTest.py
+++ b/RemotePython/RemotePythonUnitTest.py
@@ -68,9 +68,8 @@ class Test(unittest.TestCase):
         obj.runCommand(['mkdir', '-p', 'bin;', # create folder if not there
                         'ln', '-s', '/bin/ls', '~/bin/testingCommand;', # Symbolic link  to ls command
                         'touch', 'TemporaryTestFile']) #create temporary file to look for
-        ret = obj.runCommand(['testingCommand;',
-                              'rm', '~/bin/testingCommand TemporaryTestFile'],
-                             load_env=True) # Environment command execution and cleanup
+        ret = obj.runCommand(['testingCommand'], load_env=True) # Environment command execution
+        obj.runCommand(['rm', '~/bin/testingCommand TemporaryTestFile']) # Cleanup
         self.assertIn('TemporaryTestFile', ret)
 
     def testRemoveScript(self):


### PR DESCRIPTION
Pull request #15 from mdc with some tweeks

Removed the conditional testSkip as it now also works on localhost.
On OSX there is no default expansion of the PATH when sourcing .bash_profile so this might still cause the testLoadEnv() to fail.
Also added a check if ~./ bin exists before we start and removed it if it did not exist before we created it.